### PR TITLE
Fixes to cwl-tes FTP code

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -210,8 +210,12 @@ class FtpFsAccess(StdFsAccess):
     def listdir(self, fn):  # type: (Text) -> List[Text]
         ftp = self._connect(fn)
         if ftp:
-            host, _, _, path = self._parse_url(fn)
-            return ["ftp://{}/{}".format(host, x) for x in ftp.nlst(path)]
+            host, username, passwd, path = self._parse_url(fn)
+            if username != "anonymous":
+                template = "ftp://{}:{}@{}/{}"
+            else:
+                template = "ftp://{}/{}"
+            return [template.format(host, username, passwd, x) for x in ftp.nlst(path)]
         return super(FtpFsAccess, self).listdir(fn)
 
     def join(self, path, *paths):  # type: (Text, *Text) -> Text

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -36,10 +36,11 @@ def abspath(src, basedir):  # type: (Text, Text) -> Text
 
 class FtpFsAccess(StdFsAccess):
     """FTP access with upload."""
-    def __init__(self, basedir, cache=None):  # type: (Text) -> None
+    def __init__(self, basedir, cache=None, insecure=False):  # type: (Text) -> None
         super(FtpFsAccess, self).__init__(basedir)
         self.cache = cache or {}
         self.netrc = None
+        self.insecure = insecure
         try:
             if 'HOME' in os.environ:
                 if os.path.exists(os.path.join(os.environ['HOME'], '.netrc')):
@@ -81,7 +82,7 @@ class FtpFsAccess(StdFsAccess):
             ftp = ftplib.FTP_TLS()
             ftp.set_debuglevel(1 if _logger.isEnabledFor(logging.DEBUG) else 0)
             ftp.connect(host)
-            ftp.login(user, passwd)
+            ftp.login(user, passwd, secure=not self.insecure)
             self.cache[(host, user, passwd)] = ftp
             return ftp
         return None

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -19,11 +19,6 @@ from cwltool.stdfsaccess import StdFsAccess
 from cwltool.loghandler import _logger
 
 
-SECURE_FTP_PROTOCOLS = ("ftps", "sftp")
-OPEN_FTP_PROTOCOLS = ("ftp", )
-FTP_PROTOCOLS = SECURE_FTP_PROTOCOLS + OPEN_FTP_PROTOCOLS
-
-
 def abspath(src, basedir):  # type: (Text, Text) -> Text
     """http(s):, file:, ftp:, and plain path aware absolute path"""
     scheme = urllib.parse.urlparse(src).scheme
@@ -78,18 +73,12 @@ class FtpFsAccess(StdFsAccess):
 
     def _connect(self, url):  # type: (Text) -> Optional[ftplib.FTP]
         parse = urllib.parse.urlparse(url)
-        protocol = parse.scheme
-        if protocol in FTP_PROTOCOLS:
+        if parse.scheme == 'ftp':
             host, user, passwd, _ = self._parse_url(url)
             if (host, user, passwd) in self.cache:
                 if self.cache[(host, user, passwd)].pwd():
                     return self.cache[(host, user, passwd)]
-            if protocol in SECURE_FTP_PROTOCOLS:
-                ftp = ftplib.FTP_TLS()
-            elif protocol in OPEN_FTP_PROTOCOLS:
-                ftp = ftplib.FTP()
-            else:
-                logging.error(f"Did not recognize protocol {protocol}")
+            ftp = ftplib.FTP_TLS()
             ftp.set_debuglevel(1 if _logger.isEnabledFor(logging.DEBUG) else 0)
             ftp.connect(host)
             ftp.login(user, passwd)

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -68,8 +68,12 @@ class FtpFsAccess(StdFsAccess):
                 if creds:
                     user, _, passwd = creds
         if not user:
-            user = "anonymous"
-            passwd = "anonymous@"
+            user, passwd = self._recall_credentials(host)
+            if passwd is None:
+                passwd = "anonymous@"
+                if user is None:
+                    user = "anonymous"
+
         return host, user, passwd, path
 
     def _connect(self, url):  # type: (Text) -> Optional[ftplib.FTP]
@@ -95,6 +99,12 @@ class FtpFsAccess(StdFsAccess):
 
     def _abs(self, p):  # type: (Text) -> Text
         return abspath(p, self.basedir)
+
+    def _recall_credentials(self, desired_host):
+        for host, user, passwd in self.cache:
+            if desired_host == host:
+                return user, passwd
+        return None, None
 
     def glob(self, pattern):  # type: (Text) -> List[Text]
         if not self.basedir.startswith("ftp:"):

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -212,10 +212,11 @@ class FtpFsAccess(StdFsAccess):
         if ftp:
             host, username, passwd, path = self._parse_url(fn)
             if username != "anonymous":
-                template = "ftp://{}:{}@{}/{}"
+                template = "ftp://{un}:{pw}@{0}/{1}"
             else:
-                template = "ftp://{}/{}"
-            return [template.format(host, username, passwd, x) for x in ftp.nlst(path)]
+                template = "ftp://{0}/{1}"
+            return [template.format(host, item, un=username, pw=passwd)
+                    for item in ftp.nlst(path)]
         return super(FtpFsAccess, self).listdir(fn)
 
     def join(self, path, *paths):  # type: (Text, *Text) -> Text

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -155,9 +155,11 @@ def main(args=None):
 
     class CachingFtpFsAccess(FtpFsAccess):
         """Ensures that the FTP connection cache is shared."""
-        def __init__(self, basedir):
-            super(CachingFtpFsAccess, self).__init__(basedir, ftp_cache)
-    ftp_fs_access = CachingFtpFsAccess(os.curdir)
+        def __init__(self, basedir, insecure=False):
+            super(CachingFtpFsAccess, self).__init__(
+                basedir, ftp_cache, insecure=insecure)
+
+    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
     if parsed_args.remote_storage_url:
         parsed_args.remote_storage_url = ftp_fs_access.join(
             parsed_args.remote_storage_url, str(uuid.uuid4()))
@@ -167,7 +169,8 @@ def main(args=None):
         remote_storage_url=parsed_args.remote_storage_url,
         token=parsed_args.token)
     runtime_context = cwltool.main.RuntimeContext(vars(parsed_args))
-    runtime_context.make_fs_access = CachingFtpFsAccess
+    runtime_context.make_fs_access = functools.partial(
+        CachingFtpFsAccess, insecure=parsed_args.insecure)
     runtime_context.path_mapper = functools.partial(
         TESPathMapper, fs_access=ftp_fs_access)
     job_executor = MultithreadedJobExecutor() if parsed_args.parallel \
@@ -407,6 +410,9 @@ def arg_parser():  # type: () -> argparse.ArgumentParser
                         type=Text, default=os.path.abspath('.'),
                         help="Output directory, default current directory")
     parser.add_argument("--remote-storage-url", type=str)
+    parser.add_argument("--insecure", action="store_true",
+                        help=("Connect securely to FTP server (ignored when "
+                              "--remote-storage-url is not set)"))
     parser.add_argument("--token", type=str)
     parser.add_argument("--token-public-key", type=str,
                         default=DEFAULT_TOKEN_PUBLIC_KEY)

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -368,7 +368,7 @@ def set_secondary(typedef, fileobj, discovered):
     if isinstance(fileobj, MutableMapping) and fileobj.get("class") == "File":
         if "secondaryFiles" not in fileobj:
             fileobj["secondaryFiles"] = cmap(
-                [{"location": substitute(fileobj["location"], sf),
+                [{"location": substitute(fileobj["location"], sf["pattern"]),
                   "class": "File"} for sf in typedef["secondaryFiles"]])
             if discovered is not None:
                 discovered[fileobj["location"]] = fileobj["secondaryFiles"]


### PR DESCRIPTION
* `ftp._connect` now uses `urlparse.host` instead of `urlparse.netloc` as the url for the ftp. This means the username and password will not be communicated to the ftp server as part of the url string, but are instead communicated separately through the `ftplib.FTP.login` method. 
* The ftp script will now switch between using `ftplib.FTP` and `ftplib.FTP_TLS` as the class to interface with the FTP, depending on the ftp protocol in the url (`FTP_TLS` is used for sftp and ftps). 
* A bug in `main.tes_execute.set_secondary` has been fixed.  Previously the dictionary representing a secondary file entry was passed to a function instead of the specific value in the dictionary that the function requires, which raised a `TypeError` for passing a dictionary in place of a string. 
* Previously there would circumstances that would cause `cwl-tes` to send ftp requests without adding the credential data to the request. This has been fixed by leveraging the already-existing data structure `FtpFsAccess.cache`, which stores `ftplib.FTP` objects representing open connections. If an `FtpFsAccess` object is asked to make a request to an FTP server that has an open connection in `cache`, but the credential information was not explicitly provided in the url then `cwl-tes` will use the credential information stored in `cache` to login. If multiple open credentials to the server are stored in `cache`, the first encountered one will be used. This variable `cache` does not persist beyond the life of its `FtpFsAccess` object and will not persist between `cwl-tes` sessions. 