### PR TITLE
Fix FTP Download/PASV issues (e.g. docker stack deploy on a Mac)

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -147,7 +147,6 @@ class FtpFsAccess(StdFsAccess):
         return results
 
     def open(self, fn, mode):
-        print("***pycurl open***")
         if not fn.startswith("ftp:"):
             return super(FtpFsAccess, self).open(fn, mode)
         if 'r' in mode:
@@ -161,7 +160,8 @@ class FtpFsAccess(StdFsAccess):
                 c.perform()
                 response_code = c.getinfo(c.RESPONSE_CODE)
                 if not (200 <= response_code <= 299):
-                    print(f"There was a problem downloading {c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
+                    print("There was a problem downloading " +
+                          f"{c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
                 c.close()
                 temp_fname = dest.name
 
@@ -249,7 +249,7 @@ class FtpFsAccess(StdFsAccess):
             c.setopt(c.URL, url)
             c.perform()
             return int(c.getinfo(c.CONTENT_LENGTH_DOWNLOAD))
-        except:
+        except Exception:
             return super(FtpFsAccess, self).size(fn)
 
     def upload(self, file_handle, url):
@@ -262,7 +262,8 @@ class FtpFsAccess(StdFsAccess):
         c.perform()
         response_code = c.getinfo(c.RESPONSE_CODE)
         if not (200 <= response_code <= 299):
-            print(f"There was a problem uploading {c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
+            print("There was a problem uploading " +
+                  f"{c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
         c.close()
 
     def download(self, file_handle, url):
@@ -273,5 +274,6 @@ class FtpFsAccess(StdFsAccess):
         c.perform()
         response_code = c.getinfo(c.RESPONSE_CODE)
         if not (200 <= response_code <= 299):
-            print(f"There was a problem downloading {c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
+            print("There was a problem downloading " +
+                  f"{c.getinfo(c.EFFECTIVE_URL)} ({response_code})")
         c.close()

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -16,9 +16,19 @@ from six.moves import urllib
 from schema_salad.ref_resolver import uri_file_path
 from typing import Tuple, Optional
 from tempfile import NamedTemporaryFile
+from contextlib import contextmanager
 
 from cwltool.stdfsaccess import StdFsAccess
 from cwltool.loghandler import _logger
+
+
+@contextmanager
+def use_and_delete(fname, mode='r'):
+    try:
+        with open(fname, mode=mode) as fp:
+            yield fp
+    finally:
+        os.unlink(fname)
 
 
 def abspath(src, basedir):  # type: (Text, Text) -> Text
@@ -166,7 +176,7 @@ class FtpFsAccess(StdFsAccess):
                 temp_fname = dest.name
 
             # Return a file handle in read mode
-            handle = open(temp_fname, mode)
+            handle = use_and_delete(temp_fname, mode)
             if PY2:
                 return contextlib.closing(handle)
             return handle

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -24,6 +24,10 @@ from cwltool.loghandler import _logger
 
 @contextmanager
 def use_and_delete(fname, mode='r'):
+    '''
+    Acquires resource, suspends operation and yields it to caller. When
+    caller leaves its with-context, remaining resources are cleaned up.
+    '''
     try:
         with open(fname, mode=mode) as fp:
             yield fp
@@ -162,7 +166,7 @@ class FtpFsAccess(StdFsAccess):
         if 'r' in mode:
             host, user, passwd, path = self._parse_url(fn)
             url = "ftp://{}:{}@{}/{}".format(user, passwd, host, path)
-            # ftp = self._connect(fn)
+            # Get FTP file handle by temporarily downloading file
             with NamedTemporaryFile(mode='wb', delete=False) as dest:
                 c = pycurl.Curl()
                 c.setopt(c.URL, url)

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -37,7 +37,7 @@ def abspath(src, basedir):  # type: (Text, Text) -> Text
 
 class FtpFsAccess(StdFsAccess):
     """FTP access with upload."""
-    def __init__(self, basedir, cache=None, insecure=False):  # type: (Text) -> None
+    def __init__(self, basedir, cache=None, insecure=False):  # t:(Text)->None
         super(FtpFsAccess, self).__init__(basedir)
         self.cache = cache or {}
         self.netrc = None
@@ -149,14 +149,16 @@ class FtpFsAccess(StdFsAccess):
         if not fn.startswith("ftp:"):
             return super(FtpFsAccess, self).open(fn, mode)
         if 'r' in mode:
-            #host, user, passwd, path = self._parse_url(fn)
-            #handle = urllib.request.urlopen(
+            # host, user, passwd, path = self._parse_url(fn)
+            # handle = urllib.request.urlopen(
             #    "ftp://{}:{}@{}/{}".format(user, passwd, host, path))
             ftp = self._connect(fn)
             with NamedTemporaryFile(mode='wb', delete=False) as dest:
                 ftp.retrbinary("RETR {}".format(self._parse_url(fn)[3]),
-                           dest.write, 1024)
+                               dest.write, 1024)
                 temp_fname = dest.name
+            # Return a file handle in read mode
+            handle = open(temp_fname, mode)
             if PY2:
                 return contextlib.closing(handle)
             return handle
@@ -256,4 +258,5 @@ class FtpFsAccess(StdFsAccess):
     def download(self, file_handle, url):
         """FtpFsAccess specific method to download a file to the given URL."""
         ftp = self._connect(url)
-        ftp.retrbinary("RETR {}".format(self._parse_url(url)[3]), file_handle.write, 1024)
+        ftp.retrbinary("RETR {}".format(self._parse_url(url)[3]),
+                       file_handle.write, 1024)

--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -246,3 +246,8 @@ class FtpFsAccess(StdFsAccess):
         """FtpFsAccess specific method to upload a file to the given URL."""
         ftp = self._connect(url)
         ftp.storbinary("STOR {}".format(self._parse_url(url)[3]), file_handle)
+
+    def download(self, file_handle, url):
+        """FtpFsAccess specific method to download a file to the given URL."""
+        ftp = self._connect(url)
+        ftp.retrbinary("RETR {}".format(self._parse_url(url)[3]), file_handle.write, 1024)

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -159,7 +159,8 @@ def main(args=None):
             super(CachingFtpFsAccess, self).__init__(
                 basedir, ftp_cache, insecure=insecure)
 
-    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
+    ftp_fs_access = CachingFtpFsAccess(os.curdir,
+                                       insecure=parsed_args.insecure)
     if parsed_args.remote_storage_url:
         parsed_args.remote_storage_url = ftp_fs_access.join(
             parsed_args.remote_storage_url, str(uuid.uuid4()))

--- a/cwl_tes/tes.py
+++ b/cwl_tes/tes.py
@@ -89,11 +89,6 @@ class TESPathMapper(PathMapper):
     def _download_ftp_file(self, path):
         with NamedTemporaryFile(mode='wb', delete=False) as dest:
             self.fs_access.download(dest, path)
-            # with self.fs_access.open(path, mode="rb") as handle:
-            #    chunk = "start"
-            #    while chunk:
-            #        chunk = handle.read(16384)
-            #        dest.write(chunk)
             return dest.name
 
     def visit(self, obj, stagedir, basedir, copy=False, staged=False):

--- a/cwl_tes/tes.py
+++ b/cwl_tes/tes.py
@@ -89,7 +89,7 @@ class TESPathMapper(PathMapper):
     def _download_ftp_file(self, path):
         with NamedTemporaryFile(mode='wb', delete=False) as dest:
             self.fs_access.download(dest, path)
-            #with self.fs_access.open(path, mode="rb") as handle:
+            # with self.fs_access.open(path, mode="rb") as handle:
             #    chunk = "start"
             #    while chunk:
             #        chunk = handle.read(16384)

--- a/cwl_tes/tes.py
+++ b/cwl_tes/tes.py
@@ -88,11 +88,12 @@ class TESPathMapper(PathMapper):
 
     def _download_ftp_file(self, path):
         with NamedTemporaryFile(mode='wb', delete=False) as dest:
-            with self.fs_access.open(path, mode="rb") as handle:
-                chunk = "start"
-                while chunk:
-                    chunk = handle.read(16384)
-                    dest.write(chunk)
+            self.fs_access.download(dest, path)
+            #with self.fs_access.open(path, mode="rb") as handle:
+            #    chunk = "start"
+            #    while chunk:
+            #        chunk = handle.read(16384)
+            #        dest.write(chunk)
             return dest.name
 
     def visit(self, obj, stagedir, basedir, copy=False, staged=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ requests>=2.18.2
 py-tes>=0.4.0
 PyJWT>=1.6.4
 typing_extensions>=3.7.4
-pycurl>=7.43.0.5 
+pycurl>=7.43.0.5
+cryptography>=1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.18.2
 py-tes>=0.4.0
 PyJWT>=1.6.4
 typing_extensions>=3.7.4
+pycurl>=7.43.0.5 


### PR DESCRIPTION
This changes the way files are downloaded from FTP. A dedicated `download` function is added to FtpFsAccess and then used in `_download_ftp_file`. This enables `cwl-tes` to proceed further if run against a `tes_ftp` service deployed with `docker stack deploy` on a Mac (`docker-compose up` and Linux continue to work).

However, an error still occurs, but it originates from a call in `cwltool`:
```
ERROR ("Error collecting output for parameter 'output_file':\nmd5.cwl:32:3: <urlopen error ftp error: TimeoutError(60, 'Operation timed out')>", {})
Traceback (most recent call last):
  File "/Users/asenf/opt/anaconda3/lib/python3.7/urllib/request.py", line 1540, in ftp_open
    fp, retrlen = fw.retrfile(file, type)
  File "/Users/asenf/opt/anaconda3/lib/python3.7/urllib/request.py", line 2404, in retrfile
    conn, retrlen = self.ftp.ntransfercmd(cmd)
```