### PR TITLE
Patches to work around docker for mac routing

### DIFF
--- a/cwl_tes/ftp.py
+++ b/cwl_tes/ftp.py
@@ -45,7 +45,9 @@ class FTP_TLS(ftplib.FTP_TLS):
 
     def makepasv(self):
         if self.epsv:
-            host, port = ftplib.parse229(self.sendcmd('EPSV'), self.sock.getpeername())
+            host, port = ftplib.parse229(
+                self.sendcmd('EPSV'), self.sock.getpeername()
+            )
 
             return host, port
 
@@ -55,7 +57,8 @@ class FTP_TLS(ftplib.FTP_TLS):
 
 class FtpFsAccess(StdFsAccess):
     """FTP access with upload."""
-    def __init__(self, basedir, cache=None, insecure=False):  # type: (Text) -> None
+    def __init__(self, basedir, cache=None, insecure=False):
+        # type: (Text) -> None
         super(FtpFsAccess, self).__init__(basedir)
         self.cache = cache or {}
         self.netrc = None
@@ -175,7 +178,7 @@ class FtpFsAccess(StdFsAccess):
             ftp = self._connect(fn)
             with NamedTemporaryFile(mode='wb', delete=False) as dest:
                 ftp.retrbinary("RETR {}".format(self._parse_url(fn)[3]),
-                           dest.write, 1024)
+                               dest.write, 1024)
                 temp_fname = dest.name
             # Return a file handle in read mode
             handle = open(temp_fname, mode)

--- a/cwl_tes/main.py
+++ b/cwl_tes/main.py
@@ -159,7 +159,9 @@ def main(args=None):
             super(CachingFtpFsAccess, self).__init__(
                 basedir, ftp_cache, insecure=insecure)
 
-    ftp_fs_access = CachingFtpFsAccess(os.curdir, insecure=parsed_args.insecure)
+    ftp_fs_access = CachingFtpFsAccess(
+        os.curdir, insecure=parsed_args.insecure
+    )
     if parsed_args.remote_storage_url:
         parsed_args.remote_storage_url = ftp_fs_access.join(
             parsed_args.remote_storage_url, str(uuid.uuid4()))

--- a/cwl_tes/tes.py
+++ b/cwl_tes/tes.py
@@ -10,7 +10,6 @@ from builtins import str
 import shutil
 import functools
 import uuid
-from tempfile import NamedTemporaryFile
 from pprint import pformat
 from typing import (Any, Callable, Dict, List, MutableMapping, MutableSequence,
                     Optional, Union)

--- a/cwl_tes/tes.py
+++ b/cwl_tes/tes.py
@@ -87,13 +87,9 @@ class TESPathMapper(PathMapper):
                                             separateDirs)
 
     def _download_ftp_file(self, path):
-        with NamedTemporaryFile(mode='wb', delete=False) as dest:
-            with self.fs_access.open(path, mode="rb") as handle:
-                chunk = "start"
-                while chunk:
-                    chunk = handle.read(16384)
-                    dest.write(chunk)
-            return dest.name
+
+        handle = self.fs_access.open(path, mode="rb")
+        return handle.name
 
     def visit(self, obj, stagedir, basedir, copy=False, staged=False):
         tgt = convert_pathsep_to_unix(


### PR DESCRIPTION
Well I originally made this against the ohsu repo so here's attempt two!

The problem we have is detailed here: https://github.com/docker/for-mac/issues/180#
In our particular case, sending the `PASV` command to the ftp server returns the IP address of the docker gateway, rather than the actual address. This happens seemingly regardless of the setting for `PUBLICHOST` on the ftp server, suggesting it is something being done by docker itself.

This only happens when the ftp container is deployed using `docker stack` (swarm mode), docker-compose does not create a gateway. 

These patches work by:
- patching the underlying `ftplib.TLS_FTP` class to accept a `epsv` argument, which if set to True will force the use of extended passive mode (EPSV) rather than the standard (PASV).
- avoiding the use of `urlopen` from `urllib`, as it uses ftplib itself and would run into the original issue 