### PR TITLE
FIX: Add PyCurl to setup.py install_requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ requests>=2.18.2
 py-tes>=0.4.0
 PyJWT>=1.6.4
 typing_extensions>=3.7.4
-pycurl>=7.43.0.5
+pycurl>=7.19.5
 cryptography>=1.5.2

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,9 @@ setup(
         "py-tes>=0.4.0",
         "PyJWT>=1.6.4",
         "requests>=2.14.2",
-        "typing_extensions>=3.7.4"
+        "typing_extensions>=3.7.4",
+        "pycurl>=7.19.5",
+        "cryptography>=1.5.2",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
In #2, pycurl had been added to requirements.txt but not to the `install_requires` in `setup.py`. This PR fixes that, and also installs a version of PyCurl that is available as an EDM package.